### PR TITLE
#10 - UI cleanup in preparation for GH pages first release:

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -45,11 +45,12 @@ p {
 	color: green;
 }
 
-.btn-green {
+.btn-green, #triggerZone:active, #triggerZone:focus {
 	background-color:#44c767;
 	border-color:#18ab29;
 	color:#ffffff;
 	text-shadow:0px 1px 0px #2f6627;
+	outline: 0;
 }
 .btn-green:hover {
 	background-color:#5cbf2a;
@@ -98,7 +99,7 @@ button:active {
     line-height: 32px;
 }
 
-#txtTrigger {
+#triggerZone {
 	width: 100%;
 }
 

--- a/index.html
+++ b/index.html
@@ -16,15 +16,15 @@
 <p>
 	MIDI Input: <select id="selInputs"></select>
 	<input type="checkbox" id="cbEagerInput" checked /> Eager Input
-	<input type="checkbox" id="cbReplaceOnRest" checked /> Replace all last notes on rest
+	<input type="checkbox" id="cbReplaceOnRest" checked disabled /> Replace all last notes on rest
 </p>
 <p>
 	MIDI Output: <select id="selOutputs"></select>
 	<input type="checkbox" id="cbFixedVelocity" /> Fixed output velocity
 </p>
 <p>
-	MIDI Input Channel: <select id="selInputChannel"></select>
-	<!--  MIDI Output Channel: <select id="selOutputChannel"></select>  -->
+	MIDI Input Channel: <select id="selInputChannel" disabled=""></select>
+	<!--  MIDI Output Channel: <select id="selOutputChannel" disabled></select>  -->
 	<input id="cbUseChannelFiltering" type="checkbox" /> Use channel filter
 </p>
 <p>
@@ -33,10 +33,11 @@
 
 <div id="actions">
 	<button id="btnClear" class="btn-red">Reset</button>
-	<button id="btnUndo" class="btn-red">Remove Last Note(s)</button>
+	<button id="btnUndo" class="btn-red">Delete Note(s) at Arrow</button>
 	<button id="btnPreview">Preview Last Note(s)</button>
+	<button id="btnClearLast">Clear Last Note(s)</button>
 	<button id="btnAddLast">Add Last Note(s)</button>
-	<button id="btnReset">Reset Queue Position</button>
+	<button id="btnReset" class="btn-green">Reset Queue Position</button>
 	<button id="btnPlay" class="btn-green">Play (Tap Melody)</button>
 </div>
 

--- a/js/app.js
+++ b/js/app.js
@@ -13,6 +13,7 @@ var insertPosition = -1; // the position of the next not we'll be inserting. if 
 // the position in the current queue
 var position = -1;
 
+// Page initialization
 $(document).ready(function() {
 	if (navigator.requestMIDIAccess !== undefined) {
 		navigator.requestMIDIAccess().then(initMIDI, alert);
@@ -107,7 +108,7 @@ $(document).ready(function() {
 	key('command+z, ctrl+z', removeFromQueue);
 
 	$(document).on('click', '.position', function() {
-		setQueuePosition(this);
+		setQueueInsertionPoint(this);
 	});
 
 	// window.beforeunload = function() {
@@ -373,7 +374,8 @@ function redrawQueue() {
 	});
 }
 
-function setQueuePosition(element) {
+// Sets the insertion point for the next notes in the queue
+function setQueueInsertionPoint(element) {
 	insertPosition = $(element).data('position');
 	redrawQueue();
 }

--- a/js/app.js
+++ b/js/app.js
@@ -39,9 +39,20 @@ $(document).ready(function() {
 		});
 	});
 
+	// Disable replace checkbox if eager input on
+	$('#cbEagerInput').change(function() {
+		if (this.checked) $('#cbReplaceOnRest').prop('disabled', true);
+		else $('#cbReplaceOnRest').prop('disabled', false);
+	})
 	// Listen for replace checkbox change
 	$('#cbReplaceOnRest').change(function() {
 		replaceOnRest = this.checked;
+	});
+
+	// MIDI channel selector disabled if channel filtering is off
+	$('#cbUseChannelFiltering').change(function() {
+		if (this.checked) $('#selInputChannel').prop('disabled', false);
+		else $('#selInputChannel').prop('disabled', true);
 	});
 
 	for (var i = 1; i < 17; i++) {
@@ -84,6 +95,7 @@ $(document).ready(function() {
 	});
 
 	$('#btnClear').click(clearQueue);
+	$('#btnClearLast').click(clearLastQueue);
 	$('#btnUndo').click(removeFromQueue);
 	$('#btnAddLast').click(function() { addToQueue(true); });
 	$('#btnPreview, #btnAddLast').mousedown(startPreviewNotes).mouseup(endPreviewNotes);
@@ -229,11 +241,7 @@ function addToQueue(keepQueue) {
 	redrawQueue();
 
 	// unless flag is set, remove the current queue
-	if (!keepQueue) {
-		$('#lastQueue tr td').remove();
-		$('#lastQueue tr').append($('<td>').text('None'));
-		lastQueue = [];
-	}
+	if (!keepQueue) clearLastQueue();
 
 	// scroll to note when added
 	var queueBox = $('#box');
@@ -381,6 +389,13 @@ function endPreviewNotes() {
 	$.each(lastQueue, function(i, note) {
 		selectedOutput.send([0x90, note.number, 0]);
 	});
+}
+
+// Remove notes from the preview queue
+function clearLastQueue() {
+	$('#lastQueue tr td').remove();
+	$('#lastQueue tr').append($('<td>').text('None'));
+	lastQueue = [];
 }
 
 // Log note to the MIDI monitor


### PR DESCRIPTION
- Changed "Remove Last Note(s)" button to "Delete Notes(s) at Arrow" to represent this new functionality
- Added "Clear Last Note(s)" button to clear the temporary note queue
- Color coded the buttons so that the delete buttons are red, Last Note(s) buttons are blue, and performance buttons for playing and resetting the performance queue are green
- Disabled channel filter select when channel filter checkbox isn't enabled
- Disabled replace on rest checkbox when eager input checkbox is enabled
- When the performance keyboard mode is enabled (trigger notes with keyboard) the DIV is green. Additionally, make the trigger zone take up 100% width
- Renamed setQueuePosition to setQueueInsertionPoint to be more accurate, made sure every function has a doc comment

References #10
